### PR TITLE
fix: Use existing icon for Chrome5App to prevent crash

### DIFF
--- a/components/apps/Chrome5App.tsx
+++ b/components/apps/Chrome5App.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { AppDefinition, AppComponentProps } from '../../types';
-import { Browser5Icon } from '../../constants';
+import { Browser4Icon } from '../../constants';
 
 type Status = 'Connecting...' | 'Connected' | 'Disconnected' | 'Error';
 
@@ -147,7 +147,7 @@ const Chrome5App: React.FC<AppComponentProps> = ({ setTitle: setWindowTitle }) =
 export const appDefinition: AppDefinition = {
   id: 'chrome5',
   name: 'Chrome 5',
-  icon: Browser5Icon,
+  icon: Browser4Icon,
   component: Chrome5App,
   defaultSize: { width: 1024, height: 768 },
   isPinnedToTaskbar: true,

--- a/components/constants.tsx
+++ b/components/constants.tsx
@@ -1,3 +1,5 @@
+
+
 import React from 'react';
 import { AppIconProps } from './types';
 
@@ -106,18 +108,6 @@ export const Browser4Icon: React.FC<AppIconProps> = ({ className = "w-6 h-6", is
             ${isSmall ? 'text-[8px] w-3.5 h-3.5 -bottom-0.5 -right-0.5' : 'text-[10px] w-4 h-4 -bottom-1 -right-1'}`}
         >
           4
-        </span>
-    </div>
-);
-
-export const Browser5Icon: React.FC<AppIconProps> = ({ className = "w-6 h-6", isSmall }) => (
-    <div className={`relative ${isSmall ? "w-5 h-5" : className}`}>
-        <BrowserIcon className="w-full h-full" isSmall={isSmall} />
-        <span
-            className={`absolute bg-purple-500 text-white font-bold rounded-full flex items-center justify-center border-2 border-black/80
-            ${isSmall ? 'text-[8px] w-3.5 h-3.5 -bottom-0.5 -right-0.5' : 'text-[10px] w-4 h-4 -bottom-1 -right-1'}`}
-        >
-          5
         </span>
     </div>
 );


### PR DESCRIPTION
This commit resolves the renderer crash issue by following the user's suggestion to use an existing icon instead of creating a new one.

The `Chrome5App.tsx` component now imports and uses `Browser4Icon` from `components/constants.tsx`. The problematic `Browser5Icon` that was causing a fatal SyntaxError has been removed from the codebase by restoring the constants file.

This provides a robust fix to the black screen issue.